### PR TITLE
Bump go-denvr to v0.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 )
 
 require (
-	github.com/denvrdata/go-denvr v0.2.0
+	github.com/denvrdata/go-denvr v0.3.0
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
@@ -90,6 +90,6 @@ require (
 	google.golang.org/protobuf v1.36.3 // indirect
 )
 
-// replace github.com/denvrdata/go-denvr => /Users/rory/repos/denvrdata/go-denvr
+// replace github.com/denvrdata/go-denvr => /home/rory/repos/go-denvr
 
 tool github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/cyphar/filepath-securejoin v0.2.5/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/denvrdata/go-denvr v0.2.0 h1:UdP4exB3TrvIaXEBcky4guV0zJiLHDU/di8MoX3ynQg=
-github.com/denvrdata/go-denvr v0.2.0/go.mod h1:kp6pUrq+ZzCqsIGhwFxstOx5c5i1N80CLwE0hXXWOYY=
+github.com/denvrdata/go-denvr v0.3.0 h1:EJTwcZMJGKC9ErdU2//K+YignHhCoEatZ85SrQzCKfs=
+github.com/denvrdata/go-denvr v0.3.0/go.mod h1:kp6pUrq+ZzCqsIGhwFxstOx5c5i1N80CLwE0hXXWOYY=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=


### PR DESCRIPTION
- Includes some API cleanup
- Minor API changes from api.cloud.denvrdata.com
- Re-enabling retries to improve reliability when creating many apps and vms.